### PR TITLE
Fix NameError in case of using test-unit

### DIFF
--- a/ariete.gemspec
+++ b/ariete.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rspec"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
 end

--- a/lib/ariete.rb
+++ b/lib/ariete.rb
@@ -2,7 +2,7 @@
 # Copyright (c) 2014 Moza USANE
 # This software is released under the MIT License.
 # http://opensource.org/licenses/mit-license.php
-
+require "rspec"
 require "stringio"
 
 module Ariete


### PR DESCRIPTION
「require "ariete"」 cause NameError in case of using test-unit because of ariete dependent on rspec.
This PR fix this issue.

please see [sample](https://github.com/stk132/ariete-in-test-unit)