### PR TITLE
Get faraway from a dependency of RSpec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     ariete (1.0.3)
-      rspec
 
 GEM
   remote: https://rubygems.org/
@@ -30,6 +29,7 @@ DEPENDENCIES
   ariete!
   bundler (~> 1.7)
   rake (~> 10.0)
+  rspec
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/ariete.gemspec
+++ b/ariete.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rspec"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/ariete.rb
+++ b/lib/ariete.rb
@@ -2,6 +2,7 @@
 # Copyright (c) 2014 Moza USANE
 # This software is released under the MIT License.
 # http://opensource.org/licenses/mit-license.php
+
 require "rspec"
 require "stringio"
 
@@ -22,17 +23,5 @@ module Ariete
     end
 
     module_function "capture_#{name}"
-  end
-end
-
-RSpec::Matchers.define :be_output do |expect|
-  match do |actual|
-    Ariete.capture_stdout { actual.call } == expect.to_s
-  end
-end
-
-RSpec::Matchers.define :be_output_to_stderr do |expect|
-  match do |actual|
-    Ariete.capture_stderr { actual.call } == expect.to_s
   end
 end

--- a/spec/ariete_spec.rb
+++ b/spec/ariete_spec.rb
@@ -34,16 +34,4 @@ RSpec.describe Ariete do
       it { expect(subject).to eq "Ariete means 'Lop' in Italian.\n" }
     end
   end
-
-  describe "custom matchers" do
-    describe "#be_output" do
-      subject { method(:output).to_proc }
-      it { expect(subject).to be_output "Ariete is a kind of rabbit.\n" }
-    end
-
-    describe "#be_output_to_stderr" do
-      subject { method(:output).to_proc }
-      it { expect(subject).to be_output_to_stderr "Ariete means 'Lop' in Italian.\n" }
-    end
-  end
 end


### PR DESCRIPTION
# summary

Good bye RSpec, we can use Ariete with RSpec by [ariete-rspec](https://github.com/mozamimy/ariete-rspec).